### PR TITLE
fix several clang static analyzer findings

### DIFF
--- a/UserAcct.cpp
+++ b/UserAcct.cpp
@@ -694,7 +694,6 @@ void UserAcct::delSystemRoutes(PluginContext * context)
 				k=0;
 				if (j<=len) //is there a metric (optional)
 				{
-					k=0;
 					//find the metric
 					while(route[j]!=' ' && j<=len)
 					{
@@ -836,7 +835,6 @@ void UserAcct::delSystemRoutes(PluginContext * context)
 				k=0;
 				if (j<=len) //is there a metric (optional)
 				{
-					k=0;
 					//find the metric
 					while(route[j]!=' ' && j<=len)
 					{
@@ -1000,7 +998,6 @@ void UserAcct::addSystemRoutes(PluginContext * context)
 				k=0;
 				if (j<=len) //is there a metric (optional)
 				{
-					k=0;
 					//find the metric
 					while(route[j]!=' ' && j<=len)
 					{
@@ -1141,7 +1138,6 @@ void UserAcct::addSystemRoutes(PluginContext * context)
 				k=0;
 				if (j<=len) //is there a metric (optional)
 				{
-					k=0;
 					//find the metric
 					while(route[j]!=' ' && j<=len)
 					{


### PR DESCRIPTION
UserAcct.cpp:694:5: warning: Value stored to 'k' is never read
                                k=0;
                                ^ ~
UserAcct.cpp:836:5: warning: Value stored to 'k' is never read
                                k=0;
                                ^ ~
UserAcct.cpp:1000:5: warning: Value stored to 'k' is never read
                                k=0;
                                ^ ~
UserAcct.cpp:1141:5: warning: Value stored to 'k' is never read
                                k=0;
                                ^ ~