### PR TITLE
Use proper environment variables for Accounting-Request

### DIFF
--- a/AuthenticationProcess.cpp
+++ b/AuthenticationProcess.cpp
@@ -59,6 +59,7 @@ void AuthenticationProcess::Authentication(PluginContext * context)
    	// Event loop
   	while (1)
     {
+        step=0;
     	// get a command from foreground process 
       	command = context->authsocketforegr.recvInt();
       
@@ -71,22 +72,22 @@ void AuthenticationProcess::Authentication(PluginContext * context)
 		  	{
 			    user=new UserAuth;
 			    //get the user informations
-                step++;
+                step++;//1
 			    user->setUsername(context->authsocketforegr.recvStr());
-                step++;
+                step++;//2
                 user->setPassword(context->authsocketforegr.recvStr());
-                step++;
+                step++;//3
                 user->setDev(context->authsocketforegr.recvStr());
-                step++;
+                step++;//4
                 user->setPortnumber(context->authsocketforegr.recvInt());
-                step++;
+                step++;//5
                 user->setSessionId(context->authsocketforegr.recvStr());
-                step++;
+                step++;//6
                 user->setCallingStationId(context->authsocketforegr.recvStr());
-                step++;
+                step++;//7
                 user->setCommonname(context->authsocketforegr.recvStr());
 				// framed-ip is an @IP if we're renegotiating, "" otherwise
-                step++;
+                step++;//8
                 user->setFramedIp(context->authsocketforegr.recvStr());
 		 		
                 if (DEBUG (context->getVerbosity()) && (user->getFramedIp().compare("") == 0))
@@ -96,49 +97,49 @@ void AuthenticationProcess::Authentication(PluginContext * context)
 			    cerr << getTime() << "RADIUS-PLUGIN: BACKGROUND  AUTH: Old user ReAuth: username: " << user->getUsername() << ", password: *****, calling station: " << user->getCallingStationId() << ", commonname: " << user->getCommonname() << ".\n";
 			    
 			    //send the AcceptRequestPacket
-                step++;
+                step++;//9
                 if (user->sendAcceptRequestPacket(context)==0) /* Succeeded */
 			    {
 			     	//if the authentication succeeded
 			     	//create the user configuration file
 			     	//Unless this is a renegotiation (ie: if FramedIP is already set)
-                    step++;
+                    step++;//10
                     if (user->createCcdFile(context)>0 && (user->getFramedIp().compare("") == 0))
 			     	{
 			     		throw Exception ("RADIUS-PLUGIN: BACKGROUND AUTH: Ccd-file could not created for user with commonname: "+user->getCommonname()+"!\n");
 			     	}
 			     				     	
 			     	//tell the parent process
-                    step++;
+                    step++;//11
                     context->authsocketforegr.send(RESPONSE_SUCCEEDED);
 								     	
 			     	//send the routes to the parent process
-                    step++;
+                    step++;//12
                     context->authsocketforegr.send(user->getFramedRoutes());
 					
 				//send the framed ip to the parent process
-                    step++;
+                    step++;//13
                     context->authsocketforegr.send(user->getFramedIp());
 										
 			     	//send the IPv6 routes to the parent process
-                    step++;
+                    step++;//14
                     context->authsocketforegr.send(user->getFramedRoutes6());
 					
 				//send the framed IPv6 to the parent process
-                    step++;
+                    step++;//15
                     context->authsocketforegr.send(user->getFramedIp6());
 										
 					//send the interval to the parent process
-                    step++;
+                    step++;//16
                     context->authsocketforegr.send(user->getAcctInterimInterval());
 			     	
 			     	//send the vsa buffer
-                    step++;
+                    step++;//17
                     context->authsocketforegr.send(user->getVsaBuf(), user->getVsaBufLen());
 			     	
 			     	
 			     	//free user_context_auth
-                    step++;
+                    step++;//18
                     delete user;
 			     	
 			     	if (DEBUG (context->getVerbosity()))
@@ -147,7 +148,7 @@ void AuthenticationProcess::Authentication(PluginContext * context)
 			    }
 			    else /* Failed */
 			    {
-                    step++;
+                    step++;//10
                     context->authsocketforegr.send(RESPONSE_FAILED);
 					throw Exception("RADIUS-PLUGIN: BACKGROUND  AUTH: Auth failed!.\n");	
 			    }

--- a/AuthenticationProcess.cpp
+++ b/AuthenticationProcess.cpp
@@ -42,7 +42,8 @@ void AuthenticationProcess::Authentication(PluginContext * context)
 {
 	UserAuth *		user; 		/**<The user to authenticate.*/
   	int 			command;	/**<A command from the parent process.*/
-  
+    int step = 0;
+
  	//Tell the parent everythink is ok.
   	try
   	{
@@ -70,67 +71,84 @@ void AuthenticationProcess::Authentication(PluginContext * context)
 		  	{
 			    user=new UserAuth;
 			    //get the user informations
+                step++;
 			    user->setUsername(context->authsocketforegr.recvStr());
-			    user->setPassword(context->authsocketforegr.recvStr());
-			    user->setDev(context->authsocketforegr.recvStr());
-			    user->setPortnumber(context->authsocketforegr.recvInt());
-			    user->setSessionId(context->authsocketforegr.recvStr());
-			    user->setCallingStationId(context->authsocketforegr.recvStr());
-			    user->setCommonname(context->authsocketforegr.recvStr());
+                step++;
+                user->setPassword(context->authsocketforegr.recvStr());
+                step++;
+                user->setDev(context->authsocketforegr.recvStr());
+                step++;
+                user->setPortnumber(context->authsocketforegr.recvInt());
+                step++;
+                user->setSessionId(context->authsocketforegr.recvStr());
+                step++;
+                user->setCallingStationId(context->authsocketforegr.recvStr());
+                step++;
+                user->setCommonname(context->authsocketforegr.recvStr());
 				// framed-ip is an @IP if we're renegotiating, "" otherwise
-			    user->setFramedIp(context->authsocketforegr.recvStr());
+                step++;
+                user->setFramedIp(context->authsocketforegr.recvStr());
 		 		
-			    if (DEBUG (context->getVerbosity()) && (user->getFramedIp().compare("") == 0))
+                if (DEBUG (context->getVerbosity()) && (user->getFramedIp().compare("") == 0))
 			    cerr << getTime() << "RADIUS-PLUGIN: BACKGROUND  AUTH: New user auth: username: " << user->getUsername() << ", password: *****, calling station: " << user->getCallingStationId() << ", commonname: " << user->getCommonname() << ".\n";
 
 			    if (DEBUG (context->getVerbosity()) && (user->getFramedIp().compare("") !=0 ))
 			    cerr << getTime() << "RADIUS-PLUGIN: BACKGROUND  AUTH: Old user ReAuth: username: " << user->getUsername() << ", password: *****, calling station: " << user->getCallingStationId() << ", commonname: " << user->getCommonname() << ".\n";
 			    
 			    //send the AcceptRequestPacket
-			    if (user->sendAcceptRequestPacket(context)==0) /* Succeeded */
+                step++;
+                if (user->sendAcceptRequestPacket(context)==0) /* Succeeded */
 			    {
 			     	//if the authentication succeeded
 			     	//create the user configuration file
 			     	//Unless this is a renegotiation (ie: if FramedIP is already set)
-			     	if (user->createCcdFile(context)>0 && (user->getFramedIp().compare("") == 0))
+                    step++;
+                    if (user->createCcdFile(context)>0 && (user->getFramedIp().compare("") == 0))
 			     	{
 			     		throw Exception ("RADIUS-PLUGIN: BACKGROUND AUTH: Ccd-file could not created for user with commonname: "+user->getCommonname()+"!\n");
 			     	}
 			     				     	
 			     	//tell the parent process
-			     	context->authsocketforegr.send(RESPONSE_SUCCEEDED);
+                    step++;
+                    context->authsocketforegr.send(RESPONSE_SUCCEEDED);
 								     	
 			     	//send the routes to the parent process
-			     	context->authsocketforegr.send(user->getFramedRoutes());
+                    step++;
+                    context->authsocketforegr.send(user->getFramedRoutes());
 					
 				//send the framed ip to the parent process
-			     	context->authsocketforegr.send(user->getFramedIp());
+                    step++;
+                    context->authsocketforegr.send(user->getFramedIp());
 										
 			     	//send the IPv6 routes to the parent process
-			     	context->authsocketforegr.send(user->getFramedRoutes6());
+                    step++;
+                    context->authsocketforegr.send(user->getFramedRoutes6());
 					
 				//send the framed IPv6 to the parent process
-			     	context->authsocketforegr.send(user->getFramedIp6());
+                    step++;
+                    context->authsocketforegr.send(user->getFramedIp6());
 										
 					//send the interval to the parent process
-			     	context->authsocketforegr.send(user->getAcctInterimInterval());
+                    step++;
+                    context->authsocketforegr.send(user->getAcctInterimInterval());
 			     	
 			     	//send the vsa buffer
-			     	context->authsocketforegr.send(user->getVsaBuf(), user->getVsaBufLen());
+                    step++;
+                    context->authsocketforegr.send(user->getVsaBuf(), user->getVsaBufLen());
 			     	
 			     	
 			     	//free user_context_auth
-			     	delete user;
+                    step++;
+                    delete user;
 			     	
 			     	if (DEBUG (context->getVerbosity()))
 		    			cerr << getTime() << "RADIUS-PLUGIN: BACKGROUND  AUTH: Auth succeeded in radius_server().\n";
-			  		
-			  		
 			    	
 			    }
 			    else /* Failed */
 			    {
-			    	context->authsocketforegr.send(RESPONSE_FAILED);
+                    step++;
+                    context->authsocketforegr.send(RESPONSE_FAILED);
 					throw Exception("RADIUS-PLUGIN: BACKGROUND  AUTH: Auth failed!.\n");	
 			    }
 		  	}
@@ -144,7 +162,7 @@ void AuthenticationProcess::Authentication(PluginContext * context)
 				}
 		    }
 		    catch(std::bad_alloc){
-		      cerr << getTime() << "RADIUS-PLUGIN: BACKGROUND AUTH: New failed for UserAuth." << endl;
+              cerr << getTime() << "RADIUS-PLUGIN: BACKGROUND AUTH: New failed for UserAuth. (step = "<<step<< ")" << endl;
 		      goto done;
 		    }
 		    catch (...)

--- a/RadiusClass/RadiusPacket.cpp
+++ b/RadiusClass/RadiusPacket.cpp
@@ -355,9 +355,12 @@ int RadiusPacket::unShapeRadiusPacket(void)
 		{
 			return TO_BIG_ATTRIBUTE_LENGTH;
 		}
+        else if (ra->getLength()<2)
+        {
+            return BAD_LENGTH;
+        }
 		else
 		{
-				
 			value=new char [ra->getLength()-2];
 			for(i=0;i<(ra->getLength()-2);i++)
 			{

--- a/RadiusClass/RadiusPacket.cpp
+++ b/RadiusClass/RadiusPacket.cpp
@@ -479,54 +479,61 @@ int RadiusPacket::radiusReceive(list<RadiusServer> *serverlist)
 	int i_server=serverlist->size(),i=0;
 	server=serverlist->begin();
 	
+    int step = 0;
+
 	while (i<i_server)
 	{		
+        try
+        {
 		//	Get server IP address (no check if input is IP address or DNS name
 	    if(!(h=gethostbyname(server->getName().c_str())))
 		{
 			return UNKNOWN_HOST;
 		}
-		
 	    remoteServAddr.sin_family=h->h_addrtype;
 	    
-	    remoteServAddr.sin_port=htons(server->getAuthPort());
+        remoteServAddr.sin_port=htons(server->getAuthPort());
 		
 		
 	    //retry the sending if there is no result
-	    while (retries<=server->getRetry())
+        while (retries<=server->getRetry())
 	    {
+            step = 0;
 		    // wait for the specified time for a response
 		    tv.tv_sec = server->getWait();  
 		    tv.tv_usec = 0;
 		    FD_ZERO(&set);				// clear out the set 
 		    FD_SET(this->sock, &set);	// wait only for the RADIUS UDP socket 
-			result = select(FD_SETSIZE, &set, NULL, NULL, &tv);
+            step++;
+            result = select(FD_SETSIZE, &set, NULL, NULL, &tv);
 				
 			if (result>0)
 			{
-				
 				//clear the attributes
 				attribs.clear();
-		
 				
 				//allocate enough space for the buffer (RFC says maximum 4096=RADIUS_MAX_PACKET_LEN Bytes)
-				if(!(this->recvbuffer=new Octet[RADIUS_MAX_PACKET_LEN]))
+                step++;
+                if(!(this->recvbuffer=new Octet[RADIUS_MAX_PACKET_LEN]))
 				{
 					return (ALLOC_ERROR);
 				}
 				//set the buffer to 0
 				memset(this->recvbuffer,0,RADIUS_MAX_PACKET_LEN); 	
 				len=sizeof(struct sockaddr_in);
-				this->recvbufferlen=recvfrom(this->sock,this->recvbuffer,RADIUS_MAX_PACKET_LEN,0,(struct sockaddr*)&remoteServAddr,&len);
+                step++;
+                this->recvbufferlen=recvfrom(this->sock,this->recvbuffer,RADIUS_MAX_PACKET_LEN,0,(struct sockaddr*)&remoteServAddr,&len);
 				close(this->sock);
 				this->sock=0;
 				//unshape the packet
-				if(this->unShapeRadiusPacket()!=0)
+                step++;
+                if(this->unShapeRadiusPacket()!=0)
 				{
 					return UNSHAPE_ERROR;
 				}
 				
-				if (this->authenticateReceivedPacket(server->getSharedSecret().c_str())!=0)
+                step++;
+                if (this->authenticateReceivedPacket(server->getSharedSecret().c_str())!=0)
 				{
 					
 					return WRONG_AUTHENTICATOR_IN_RECV_PACKET;
@@ -541,7 +548,8 @@ int RadiusPacket::radiusReceive(list<RadiusServer> *serverlist)
 				//the server retries
 				if(retries <= server->getRetry())
 				{
-					this->radiusSend(server);
+                    step+=100;
+                    this->radiusSend(server);
 				}
 			}
 			retries++;
@@ -551,6 +559,12 @@ int RadiusPacket::radiusReceive(list<RadiusServer> *serverlist)
 		i++;
 		//set the retries=0, for the new server
 		retries=0;
+        }
+        catch(std::bad_alloc&)
+        {
+            cerr << "-------- RADIUS-PLUGIN: radiusReceive bad_alloc. (step = "<<step<< ")" << endl;
+            throw;
+        }
 	}
 	
 	return NO_RESPONSE;

--- a/RadiusClass/RadiusPacket.cpp
+++ b/RadiusClass/RadiusPacket.cpp
@@ -317,10 +317,11 @@ int RadiusPacket::unShapeRadiusPacket(void)
 {
 	RadiusAttribute		*ra;
 	int					pos,i;
-	char				*value; 			
+    char				*value;
+    unsigned int        len;
 	
 	//if the buffer is empty
-	if(!this->recvbuffer||this->recvbufferlen<=0)
+    if(!this->recvbuffer||this->recvbufferlen<=4)
 	{
 		return NO_BUFFER_TO_UNSHAPE;
 	}
@@ -329,15 +330,23 @@ int RadiusPacket::unShapeRadiusPacket(void)
 	//	RADIUS packet header decoding
 	this->code=this->recvbuffer[0];
 	//cerr << getTime() << "\n\nCODE: %s\n\n", this->code);
-	
+
 	this->identifier=this->recvbuffer[1];
+
+    len = this->recvbuffer[2]*256 + this->recvbuffer[3];
+
+    if (this->recvbufferlen < len)
+    {
+        return BAD_LENGTH;
+    }
+
 	memcpy(this->authenticator,recvbuffer+4,RADIUS_PACKET_AUTHENTICATOR_LEN);
 	
 	
 	//	RADIUS packet attributes decoding
 	pos=20;
 			
-	while(pos<this->recvbufferlen)
+    while(pos<len)
 	{
 		//for every turn create a new attribute
 		if(!(ra=new RadiusAttribute))
@@ -376,7 +385,7 @@ int RadiusPacket::unShapeRadiusPacket(void)
 		delete ra;
 	}
 	//set the right length
-	this->length=this->recvbufferlen;
+    this->length=len;
 	
 	
 	return 0;

--- a/UserAuth.cpp
+++ b/UserAuth.cpp
@@ -60,11 +60,14 @@ int UserAuth::sendAcceptRequestPacket(PluginContext * context)
 				ra9(ATTRIB_Framed_IP_Address),
 				ra10(ATTRIB_Acct_Session_ID, this->getSessionId());
 	
-	
+    int step =0;
+    try
+    {
 	if (DEBUG (context->getVerbosity()))
     	cerr << getTime() << "RADIUS-PLUGIN: radius_server().\n";
 		
 	//get the server list
+    step++;
 	serverlist=context->radiusconf.getRadiusServer();
 	//set server to the first server
 	server=serverlist->begin();
@@ -74,37 +77,43 @@ int UserAuth::sendAcceptRequestPacket(PluginContext * context)
 		cerr << getTime() << "RADIUS-PLUGIN: Build password packet:  password: *****, sharedSecret: *****.\n";
 	
 	//add the attributes
-	ra2.setValue(this->password);
+    step++;
+    ra2.setValue(this->password);
 	if(packet.addRadiusAttribute(&ra1))
 	{
 		cerr << getTime() << "RADIUS-PLUGIN: Fail to add attribute ATTRIB_User_Name.\n";
 	}
 	
-	if (packet.addRadiusAttribute(&ra2))
+    step++;
+    if (packet.addRadiusAttribute(&ra2))
 	{
 		cerr << getTime() << "RADIUS-PLUGIN: Fail to add attribute ATTRIB_User_Password.\n";
 	}
-	if (packet.addRadiusAttribute(&ra3))
+    step++;
+    if (packet.addRadiusAttribute(&ra3))
 	{
 		cerr << getTime() << "RADIUS-PLUGIN: Fail to add attribute ATTRIB_NAS_Port.\n";
 	}
-	if (packet.addRadiusAttribute(&ra4))
+    step++;
+    if (packet.addRadiusAttribute(&ra4))
 	{
 		cerr << getTime() << "RADIUS-PLUGIN: Fail to add attribute ATTRIB_Calling_Station_Id.\n";
 	}
 	//get information from the config and add it to the packet
-	if(strcmp(context->radiusconf.getNASIdentifier(),""))
+    step++;
+    if(strcmp(context->radiusconf.getNASIdentifier(),""))
 	{
-			ra5.setValue(context->radiusconf.getNASIdentifier());
-			if (packet.addRadiusAttribute(&ra5))
+            ra5.setValue(context->radiusconf.getNASIdentifier());
+            if (packet.addRadiusAttribute(&ra5))
 			{
 				cerr << getTime() << "RADIUS-PLUGIN: Fail to add attribute ATTRIB_NAS_Identifier.\n";
 			}
 	}
 	
-	if(strcmp(context->radiusconf.getNASIpAddress(),""))
+    step++;
+    if(strcmp(context->radiusconf.getNASIpAddress(),""))
 	{
-			if(ra6.setValue(context->radiusconf.getNASIpAddress())!=0)
+            if(ra6.setValue(context->radiusconf.getNASIpAddress())!=0)
 			{
 				cerr << getTime() << "RADIUS-PLUGIN: Fail to set value ATTRIB_NAS_Ip_Address.\n";
 			}
@@ -114,7 +123,8 @@ int UserAuth::sendAcceptRequestPacket(PluginContext * context)
 				cerr << getTime() << "RADIUS-PLUGIN: Fail to add attribute ATTRIB_NAS_Ip_Address.\n";
 			}
 	}
-	if(strcmp(context->radiusconf.getNASPortType(),""))
+    step++;
+    if(strcmp(context->radiusconf.getNASPortType(),""))
 	{
 			ra7.setValue(context->radiusconf.getNASPortType());
 			if (packet.addRadiusAttribute(&ra7))
@@ -123,12 +133,14 @@ int UserAuth::sendAcceptRequestPacket(PluginContext * context)
 			}
 	}
 	
-	if (packet.addRadiusAttribute(&ra10))
+    step++;
+    if (packet.addRadiusAttribute(&ra10))
 	{
 		cerr << getTime() << "RADIUS-PLUGIN: Fail to add attribute ATTRIB_Acct_Session_ID.\n";
 	}
 	
-	if(strcmp(context->radiusconf.getServiceType(),""))
+    step++;
+    if(strcmp(context->radiusconf.getServiceType(),""))
 	{
 			ra8.setValue(context->radiusconf.getServiceType());
 			if (packet.addRadiusAttribute(&ra8))
@@ -137,7 +149,8 @@ int UserAuth::sendAcceptRequestPacket(PluginContext * context)
 			}
 	}
 	
-	if(this->getFramedIp().compare("") != 0)
+    step++;
+    if(this->getFramedIp().compare("") != 0)
 	{
 		if (DEBUG (context->getVerbosity()))
 			cerr << getTime() << "RADIUS-PLUGIN: Send packet Re-Auth packet for framedIP="<< this->getFramedIp().c_str() << ".\n";
@@ -148,17 +161,19 @@ int UserAuth::sendAcceptRequestPacket(PluginContext * context)
 			}
 	}
 	
-	
-	
-	if (DEBUG (context->getVerbosity()))
+    step++;
+    if (DEBUG (context->getVerbosity()))
 		cerr << getTime() << "RADIUS-PLUGIN: Send packet to " << server->getName().c_str() <<".\n";
 	//send the packet
-	if (packet.radiusSend(server)<0)
+
+    step++;
+    if (packet.radiusSend(server)<0)
 	{
 		cerr << getTime() << "RADIUS-PLUGIN: Packet was not sent.\n";
 	}
 	//receive the packet
-	int rc=packet.radiusReceive(serverlist);
+    step++;
+    int rc=packet.radiusReceive(serverlist);
 	if (rc==0)
 	{
 		//is it a accept?
@@ -193,7 +208,13 @@ int UserAuth::sendAcceptRequestPacket(PluginContext * context)
 	{
 		cerr << getTime() << "RADIUS-PLUGIN: Got no response from radius server, return code:" << rc << endl;
 	}
-	
+    }
+    catch(std::bad_alloc&)
+    {
+        cerr << getTime() << "RADIUS-PLUGIN: sendAcceptRequestPacket bad_alloc. (step = "<<step<< ")" << endl;
+        throw;
+    }
+
 	return 1;
 		
 }

--- a/radiusplugin.cpp
+++ b/radiusplugin.cpp
@@ -403,28 +403,28 @@ error:
             try
             {
                 newuser=new UserPlugin();
-		get_user_env(context,type,envp, newuser);
-                 if (newuser->getAuthControlFile().length() > 0 && context->conf.getUseAuthControlFile())
-                                {
-                                  pthread_mutex_lock(context->getMutexSend());
-                                  context->addNewUser(newuser);
-                                  pthread_cond_signal( context->getCondSend( ));
-                                  pthread_mutex_unlock (context->getMutexSend());
-                                  return OPENVPN_PLUGIN_FUNC_DEFERRED;  
-                                }
-                                else
-                                {
-                                  pthread_mutex_lock(context->getMutexRecv());
-				  pthread_mutex_lock(context->getMutexSend());
-                                  context->addNewUser(newuser);
-                                  pthread_cond_signal( context->getCondSend( ));
-                                  pthread_mutex_unlock (context->getMutexSend());
+                get_user_env(context,type,envp, newuser);
+                if (newuser->getAuthControlFile().length() > 0 && context->conf.getUseAuthControlFile())
+                {
+                  pthread_mutex_lock(context->getMutexSend());
+                  context->addNewUser(newuser);
+                  pthread_cond_signal( context->getCondSend( ));
+                  pthread_mutex_unlock (context->getMutexSend());
+                  return OPENVPN_PLUGIN_FUNC_DEFERRED;
+                }
+                else
+                {
+                  pthread_mutex_lock(context->getMutexRecv());
+                  pthread_mutex_lock(context->getMutexSend());
+                  context->addNewUser(newuser);
+                  pthread_cond_signal( context->getCondSend( ));
+                  pthread_mutex_unlock (context->getMutexSend());
 				  
 				  pthread_cond_wait( context->getCondRecv(), context->getMutexRecv());
 				  pthread_mutex_unlock (context->getMutexRecv());
                                   
 				  return context->getResult();
-                                }
+                }
             }
             catch ( Exception &e )
             {
@@ -1135,7 +1135,15 @@ void  * client_connect(void * c)
                 }
             }
             else
-            delete(tmpuser);
+            {
+                newuser->setFramedIp(tmpuser->getFramedIp());
+                newuser->setFramedIp6(tmpuser->getFramedIp6());
+                newuser->setFramedRoutes(tmpuser->getFramedRoutes());
+                newuser->setFramedRoutes6(tmpuser->getFramedRoutes6());
+                newuser->setClientConnectDeferFile(tmpuser->getClientConnectDeferFile());
+
+                delete(tmpuser);
+            }
 
             if ( DEBUG ( context->getVerbosity() ) )
                 cerr << getTime() << "RADIUS-PLUGIN: FOREGROUND THREAD: Set FramedIP to the IP (" << newuser->getFramedIp() << ") OpenVPN assigned to the user " << newuser->getUsername() << "\n";

--- a/radiusplugin.cpp
+++ b/radiusplugin.cpp
@@ -22,6 +22,7 @@
 //The callback functions of the plugin infrastructure.
 
 #include "radiusplugin.h"
+#include <time.h>
 #define NEED_LIBGCRYPT_VERSION "1.2.0"
 GCRY_THREAD_OPTION_PTHREAD_IMPL;
 
@@ -1272,7 +1273,8 @@ string getTime()
     time_t rawtime;
     time ( &rawtime );
     char time_char[60];
-    std::strftime(time_char,sizeof(time_char),"%c ",std::localtime(&rawtime));
+    struct tm temp_tm;
+    std::strftime(time_char,sizeof(time_char),"%c ",localtime_r(&rawtime,&temp_tm));
 
     string t(time_char);
 

--- a/radiusplugin.cpp
+++ b/radiusplugin.cpp
@@ -1271,13 +1271,11 @@ string getTime()
 {
     time_t rawtime;
     time ( &rawtime );
-    string t(ctime(&rawtime));
-    t.replace(t.find("\n"),1," ");
-    size_t str_pos=t.find("\n");
-    if (str_pos!=string::npos)
-    {
-         t.replace(str_pos,1," ");
-    }
+    char time_char[60];
+    std::strftime(time_char,sizeof(time_char),"%c ",std::localtime(&rawtime));
+
+    string t(time_char);
+
     return t;
 }
 

--- a/radiusplugin.cpp
+++ b/radiusplugin.cpp
@@ -986,7 +986,7 @@ void  * auth_user_pass_verify(void * c)
                     pthread_mutex_lock(context->getMutexRecv());
                     context->setResult(OPENVPN_PLUGIN_FUNC_SUCCESS);
                     
-		    pthread_cond_signal( context->getCondRecv( ));
+                    pthread_cond_signal( context->getCondRecv( ));
                     pthread_mutex_unlock (context->getMutexRecv());
 
                 }

--- a/radiusplugin.cpp
+++ b/radiusplugin.cpp
@@ -884,8 +884,8 @@ void  * auth_user_pass_verify(void * c)
                      << "\nRADIUS-PLUGIN: FOREGROUND THREAD:\t newuser ip: " << olduser->getCallingStationId()
                      << "\nRADIUS-PLUGIN: FOREGROUND THREAD:\t newuser port: " << olduser->getUntrustedPort()
                      << "\n";
-            cerr << getTime() << "RADIUS-PLUGIN: FOREGROUND THREAD: isAuthenticated()" <<  olduser->isAuthenticated();
-            cerr << getTime() << "RADIUS-PLUGIN: FOREGROUND THREAD: isAcct()" <<  olduser->isAccounted();
+            cerr << getTime() << "RADIUS-PLUGIN: FOREGROUND THREAD: isAuthenticated()" <<  olduser->isAuthenticated() << endl;
+            cerr << getTime() << "RADIUS-PLUGIN: FOREGROUND THREAD: isAcct()" <<  olduser->isAccounted() << endl;
             // update password and username, can happen when a new connection is established from the same client with the same port before the timeout in the openvpn server occurs!
             olduser->setPassword(newuser->getPassword());
             olduser->setUsername(newuser->getUsername());


### PR DESCRIPTION
1. update fields FramedIP, FramedIP6, FramedRoutes, FramedRoutes6 for AccoutingRequest
2. update field ClientConnectDeferFile for AccountingRequest

This commit fixes uninitialized FramedIP and other variables values. Previous behavior produced packets with binary garbage in these fields.