### PR TITLE
quickfix deprecated client-cert-not-required

### DIFF
--- a/Config.cpp
+++ b/Config.cpp
@@ -232,10 +232,10 @@ int Config::parseConfigFile(const char * configfile)
 					  if (pos != string::npos) param.erase(0,pos );
 					  pos=param.find_first_of(delims);
 					  if (pos != string::npos) param.erase(pos);
-					  if (param == "client-cert-not-required")
+					  if (param == "verify-client-cert")
 					  {
 						  this->deletechars(&line);
-						  if (line == "client-cert-not-required")
+						  if (line == "verify-client-certoptional" || line == "verify-client-certnone")
 						  {
 							  this->clientcertnotrequired=true;
 						  }


### PR DESCRIPTION
OpenVPN v2.4 replace "client-cert-not-required" for the new "verify-client-cert"  
This make the plugin to fail with the error "common_name is not defined" if the server dont require user certificates